### PR TITLE
feat: add listunspent UTXO query playbooks (25 / 25b)

### DIFF
--- a/playbooks/25-listunspent.yml
+++ b/playbooks/25-listunspent.yml
@@ -1,0 +1,105 @@
+# Playbook: 25-listunspent.yml
+# Purpose: Retrieve unspent transaction outputs (UTXOs) from wallet via the verus CLI.
+#          Calls listunspent on VRSC and vDEX containers — same pattern as getinfo in 15-sync-status.yml.
+#
+# Usage:
+#   ansible-playbook -i inventory.ini playbooks/25-listunspent.yml
+#
+# Optional overrides:
+#   ansible-playbook -i inventory.ini playbooks/25-listunspent.yml -e "listunspent_minconf=0" -e "listunspent_maxconf=6"
+
+---
+- name: Get wallet UTXOs via listunspent
+  hosts: production
+  gather_facts: false
+  vars:
+    ansible_user: dream-hermes-agent
+    listunspent_minconf: "1"
+    listunspent_maxconf: "9999999"
+
+  tasks:
+    # ── VRSC ───────────────────────────────────────────────────────────────────
+    - name: Query VRSC listunspent
+      ansible.builtin.shell:
+        cmd: "docker exec mains_blue-vrsc-1 verus listunspent {{ listunspent_minconf }} {{ listunspent_maxconf }} 2>&1"
+      register: vrsc_listunspent
+      changed_when: false
+      failed_when: false
+
+    # ── vDEX ────────────────────────────────────────────────────────────────────
+    - name: Query vDEX listunspent
+      ansible.builtin.shell:
+        cmd: "docker exec mains_blue-vdex-1 verus -chain=vdex listunspent {{ listunspent_minconf }} {{ listunspent_maxconf }} 2>&1"
+      register: vdex_listunspent
+      changed_when: false
+      failed_when: false
+
+    # ── Parse VRSC ──────────────────────────────────────────────────────────────
+    - name: Set VRSC offline defaults
+      ansible.builtin.set_fact:
+        vrsc_utxos: []
+        vrsc_utxo_count: 0
+        vrsc_utxo_total: "0"
+        vrsc_online: false
+      when: not (vrsc_listunspent.stdout is search('['))
+
+    - name: Parse VRSC utxos
+      ansible.builtin.set_fact:
+        vrsc_utxos: "{{ vrsc_listunspent.stdout | from_json }}"
+        vrsc_utxo_count: "{{ (vrsc_listunspent.stdout | from_json) | length }}"
+        vrsc_utxo_total: "{{ '%.8f' | format((vrsc_listunspent.stdout | from_json) | sum(attribute='amount') | float) }}"
+        vrsc_online: true
+      when: vrsc_listunspent.stdout is search('[')
+
+    # ── Parse vDEX ──────────────────────────────────────────────────────────────
+    - name: Set vDEX offline defaults
+      ansible.builtin.set_fact:
+        vdex_utxos: []
+        vdex_utxo_count: 0
+        vdex_utxo_total: "0"
+        vdex_online: false
+      when: not (vdex_listunspent.stdout is search('['))
+
+    - name: Parse vDEX utxos
+      ansible.builtin.set_fact:
+        vdex_utxos: "{{ vdex_listunspent.stdout | from_json }}"
+        vdex_utxo_count: "{{ (vdex_listunspent.stdout | from_json) | length }}"
+        vdex_utxo_total: "{{ '%.8f' | format((vdex_listunspent.stdout | from_json) | sum(attribute='amount') | float) }}"
+        vdex_online: true
+      when: vdex_listunspent.stdout is search('[')
+
+    # ── Summary ─────────────────────────────────────────────────────────────────
+    - name: Display UTXO summary
+      ansible.builtin.debug:
+        msg: |
+          {% if vrsc_online %}
+          VRSC  — {{ vrsc_utxo_count }} UTXO(s)  ·  total {{ vrsc_utxo_total }} VRSC
+          {% else %}
+          VRSC  — offline or no wallet
+          Last output: {{ vrsc_listunspent.stderr | default(vrsc_listunspent.stdout) }}
+          {% endif %}
+          {% if vdex_online %}
+          vDEX  — {{ vdex_utxo_count }} UTXO(s)  ·  total {{ vdex_utxo_total }} vDEX
+          {% else %}
+          vDEX  — offline or no wallet
+          Last output: {{ vdex_listunspent.stderr | default(vdex_listunspent.stdout) }}
+          {% endif %}
+
+    # ── Assertions ──────────────────────────────────────────────────────────────
+    - name: Assert VRSC returned valid JSON
+      ansible.builtin.assert:
+        that:
+          - "vrsc_listunspent.rc == 0"
+          - "vrsc_listunspent.stdout is search('[')"
+        fail_msg: "VRSC listunspent failed — {{ vrsc_listunspent.stderr | default(vrsc_listunspent.stdout) }}"
+        success_msg: "VRSC listunspent returned valid JSON"
+      when: vrsc_online
+
+    - name: Assert vDEX returned valid JSON
+      ansible.builtin.assert:
+        that:
+          - "vdex_listunspent.rc == 0"
+          - "vdex_listunspent.stdout is search('[')"
+        fail_msg: "vDEX listunspent failed — {{ vdex_listunspent.stderr | default(vdex_listunspent.stdout) }}"
+        success_msg: "vDEX listunspent returned valid JSON"
+      when: vdex_online

--- a/playbooks/25-listunspent.yml
+++ b/playbooks/25-listunspent.yml
@@ -69,27 +69,13 @@
       when: "'\"confirmations\"' in vdex_listunspent.stdout"
 
     # ── Summary ─────────────────────────────────────────────────────────────────
-    - name: Display UTXO summary
+    - name: Display raw listunspent output
       ansible.builtin.debug:
         msg: |
-          {% if vrsc_online %}
-          VRSC  — {{ vrsc_utxo_count }} UTXO(s)  ·  total {{ vrsc_utxo_total }} VRSC
-          {% for utxo in vrsc_utxos %}
-            txid={{ utxo.txid }}  vout={{ utxo.vout }}  amount={{ utxo.amount }}  confirmations={{ utxo.confirmations }}
-          {% endfor %}
-          {% else %}
-          VRSC  — offline or no wallet
-          Last output: {{ vrsc_listunspent.stderr | default(vrsc_listunspent.stdout) }}
-          {% endif %}
-          {% if vdex_online %}
-          vDEX  — {{ vdex_utxo_count }} UTXO(s)  ·  total {{ vdex_utxo_total }} vDEX
-          {% for utxo in vdex_utxos %}
-            txid={{ utxo.txid }}  vout={{ utxo.vout }}  amount={{ utxo.amount }}  confirmations={{ utxo.confirmations }}
-          {% endfor %}
-          {% else %}
-          vDEX  — offline or no wallet
-          Last output: {{ vdex_listunspent.stderr | default(vdex_listunspent.stdout) }}
-          {% endif %}
+          VRSC:
+          {{ vrsc_listunspent.stdout }}
+          vDEX:
+          {{ vdex_listunspent.stdout }}
 
     # ── Assertions ──────────────────────────────────────────────────────────────
     - name: Assert VRSC returned valid JSON

--- a/playbooks/25-listunspent.yml
+++ b/playbooks/25-listunspent.yml
@@ -41,7 +41,7 @@
         vrsc_utxo_count: 0
         vrsc_utxo_total: "0"
         vrsc_online: false
-      when: not (vrsc_listunspent.stdout is search('['))
+      when: "'\"confirmations\"' not in vrsc_listunspent.stdout"
 
     - name: Parse VRSC utxos
       ansible.builtin.set_fact:
@@ -49,7 +49,7 @@
         vrsc_utxo_count: "{{ (vrsc_listunspent.stdout | from_json) | length }}"
         vrsc_utxo_total: "{{ '%.8f' | format((vrsc_listunspent.stdout | from_json) | sum(attribute='amount') | float) }}"
         vrsc_online: true
-      when: vrsc_listunspent.stdout is search('[')
+      when: "'\"confirmations\"' in vrsc_listunspent.stdout"
 
     # ── Parse vDEX ──────────────────────────────────────────────────────────────
     - name: Set vDEX offline defaults
@@ -58,7 +58,7 @@
         vdex_utxo_count: 0
         vdex_utxo_total: "0"
         vdex_online: false
-      when: not (vdex_listunspent.stdout is search('['))
+      when: "'\"confirmations\"' not in vdex_listunspent.stdout"
 
     - name: Parse vDEX utxos
       ansible.builtin.set_fact:
@@ -66,7 +66,7 @@
         vdex_utxo_count: "{{ (vdex_listunspent.stdout | from_json) | length }}"
         vdex_utxo_total: "{{ '%.8f' | format((vdex_listunspent.stdout | from_json) | sum(attribute='amount') | float) }}"
         vdex_online: true
-      when: vdex_listunspent.stdout is search('[')
+      when: "'\"confirmations\"' in vdex_listunspent.stdout"
 
     # ── Summary ─────────────────────────────────────────────────────────────────
     - name: Display UTXO summary
@@ -90,7 +90,7 @@
       ansible.builtin.assert:
         that:
           - "vrsc_listunspent.rc == 0"
-          - "vrsc_listunspent.stdout is search('[')"
+          - "'\"confirmations\"' in vrsc_listunspent.stdout"
         fail_msg: "VRSC listunspent failed — {{ vrsc_listunspent.stderr | default(vrsc_listunspent.stdout) }}"
         success_msg: "VRSC listunspent returned valid JSON"
       when: vrsc_online
@@ -99,7 +99,7 @@
       ansible.builtin.assert:
         that:
           - "vdex_listunspent.rc == 0"
-          - "vdex_listunspent.stdout is search('[')"
+          - "'\"confirmations\"' in vdex_listunspent.stdout"
         fail_msg: "vDEX listunspent failed — {{ vdex_listunspent.stderr | default(vdex_listunspent.stdout) }}"
         success_msg: "vDEX listunspent returned valid JSON"
       when: vdex_online

--- a/playbooks/25-listunspent.yml
+++ b/playbooks/25-listunspent.yml
@@ -74,12 +74,18 @@
         msg: |
           {% if vrsc_online %}
           VRSC  — {{ vrsc_utxo_count }} UTXO(s)  ·  total {{ vrsc_utxo_total }} VRSC
+          {% for utxo in vrsc_utxos %}
+            txid={{ utxo.txid }}  vout={{ utxo.vout }}  amount={{ utxo.amount }}  confirmations={{ utxo.confirmations }}
+          {% endfor %}
           {% else %}
           VRSC  — offline or no wallet
           Last output: {{ vrsc_listunspent.stderr | default(vrsc_listunspent.stdout) }}
           {% endif %}
           {% if vdex_online %}
           vDEX  — {{ vdex_utxo_count }} UTXO(s)  ·  total {{ vdex_utxo_total }} vDEX
+          {% for utxo in vdex_utxos %}
+            txid={{ utxo.txid }}  vout={{ utxo.vout }}  amount={{ utxo.amount }}  confirmations={{ utxo.confirmations }}
+          {% endfor %}
           {% else %}
           vDEX  — offline or no wallet
           Last output: {{ vdex_listunspent.stderr | default(vdex_listunspent.stdout) }}

--- a/playbooks/25b-listunspent-vrsctest.yml
+++ b/playbooks/25b-listunspent-vrsctest.yml
@@ -1,0 +1,66 @@
+# Playbook: 25b-listunspent-vrsctest.yml
+# Purpose: Retrieve unspent transaction outputs (UTXOs) from the VRSCTEST wallet.
+#          Calls listunspent via the verus CLI inside the container — same pattern
+#          as 15b-sync-status-vrsctest.yml.
+#
+# Usage:
+#   ansible-playbook -i inventory.ini playbooks/25b-listunspent-vrsctest.yml
+#
+# Optional overrides:
+#   ansible-playbook -i inventory.ini playbooks/25b-listunspent-vrsctest.yml -e "listunspent_minconf=0" -e "listunspent_maxconf=6"
+
+---
+- name: Get VRSCTEST wallet UTXOs via listunspent
+  hosts: production
+  gather_facts: false
+  vars:
+    ansible_user: dream-hermes-agent
+    listunspent_minconf: "1"
+    listunspent_maxconf: "9999999"
+
+  tasks:
+    - name: Query VRSCTEST listunspent
+      ansible.builtin.shell:
+        cmd: "docker exec dev200-vrsctest-1 verus -chain=VRSCTEST listunspent {{ listunspent_minconf }} {{ listunspent_maxconf }} 2>&1"
+      register: vrsctest_listunspent
+      changed_when: false
+      failed_when: false
+
+    # ── Offline default ─────────────────────────────────────────────────────────
+    - name: Set offline defaults
+      ansible.builtin.set_fact:
+        vrsctest_utxos: []
+        vrsctest_utxo_count: 0
+        vrsctest_utxo_total: "0"
+        vrsctest_online: false
+      when: "'\"confirmations\"' not in vrsctest_listunspent.stdout"
+
+    # ── Parse ───────────────────────────────────────────────────────────────────
+    - name: Parse VRSCTEST utxos
+      ansible.builtin.set_fact:
+        vrsctest_utxos: "{{ vrsctest_listunspent.stdout | from_json }}"
+        vrsctest_utxo_count: "{{ (vrsctest_listunspent.stdout | from_json) | length }}"
+        vrsctest_utxo_total: "{{ '%.8f' | format((vrsctest_listunspent.stdout | from_json) | sum(attribute='amount') | float) }}"
+        vrsctest_online: true
+      when: "'\"confirmations\"' in vrsctest_listunspent.stdout"
+
+    # ── Summary ─────────────────────────────────────────────────────────────────
+    - name: Display UTXO summary
+      ansible.builtin.debug:
+        msg: |
+          {% if vrsctest_online %}
+          VRSCTEST — {{ vrsctest_utxo_count }} UTXO(s)  ·  total {{ vrsctest_utxo_total }} VRSCTEST
+          {% else %}
+          VRSCTEST — offline or no wallet
+          Last output: {{ vrsctest_listunspent.stderr | default(vrsctest_listunspent.stdout) }}
+          {% endif %}
+
+    # ── Assertion ───────────────────────────────────────────────────────────────
+    - name: Assert VRSCTEST returned valid JSON
+      ansible.builtin.assert:
+        that:
+          - "vrsctest_listunspent.rc == 0"
+          - "'\"confirmations\"' in vrsctest_listunspent.stdout"
+        fail_msg: "VRSCTEST listunspent failed — {{ vrsctest_listunspent.stderr | default(vrsctest_listunspent.stdout) }}"
+        success_msg: "VRSCTEST listunspent returned valid JSON"
+      when: vrsctest_online

--- a/playbooks/25b-listunspent-vrsctest.yml
+++ b/playbooks/25b-listunspent-vrsctest.yml
@@ -50,6 +50,9 @@
         msg: |
           {% if vrsctest_online %}
           VRSCTEST — {{ vrsctest_utxo_count }} UTXO(s)  ·  total {{ vrsctest_utxo_total }} VRSCTEST
+          {% for utxo in vrsctest_utxos %}
+            txid={{ utxo.txid }}  vout={{ utxo.vout }}  amount={{ utxo.amount }}  confirmations={{ utxo.confirmations }}
+          {% endfor %}
           {% else %}
           VRSCTEST — offline or no wallet
           Last output: {{ vrsctest_listunspent.stderr | default(vrsctest_listunspent.stdout) }}

--- a/playbooks/25b-listunspent-vrsctest.yml
+++ b/playbooks/25b-listunspent-vrsctest.yml
@@ -45,18 +45,11 @@
       when: "'\"confirmations\"' in vrsctest_listunspent.stdout"
 
     # ── Summary ─────────────────────────────────────────────────────────────────
-    - name: Display UTXO summary
+    - name: Display raw listunspent output
       ansible.builtin.debug:
         msg: |
-          {% if vrsctest_online %}
-          VRSCTEST — {{ vrsctest_utxo_count }} UTXO(s)  ·  total {{ vrsctest_utxo_total }} VRSCTEST
-          {% for utxo in vrsctest_utxos %}
-            txid={{ utxo.txid }}  vout={{ utxo.vout }}  amount={{ utxo.amount }}  confirmations={{ utxo.confirmations }}
-          {% endfor %}
-          {% else %}
-          VRSCTEST — offline or no wallet
-          Last output: {{ vrsctest_listunspent.stderr | default(vrsctest_listunspent.stdout) }}
-          {% endif %}
+          VRSCTEST:
+          {{ vrsctest_listunspent.stdout }}
 
     # ── Assertion ───────────────────────────────────────────────────────────────
     - name: Assert VRSCTEST returned valid JSON


### PR DESCRIPTION
## Summary

Add  RPC query playbooks mirroring the  pattern from .

- **25-listunspent.yml** — queries VRSC and vDEX wallets via `verus listunspent`
- **25b-listunspent-vrsctest.yml** — queries VRSCTEST wallet via `verus -chain=VRSCTEST listunspent`

Both return raw JSON output. Filtering/parsing can be layered on later.

## Testing

- Playbooks tested against BWD — VRSCTEST returned valid UTXO data ✅
- VRSC and vDEX returned empty arrays (no wallet loaded at `minconf=1`)

## Runbook

See `operations/runbooks/listunspent.md` (merged separately to main).